### PR TITLE
Allow spaces in path in scripts

### DIFF
--- a/docs/guide/analog-sensor-node/update-screenshots.sh
+++ b/docs/guide/analog-sensor-node/update-screenshots.sh
@@ -1,7 +1,7 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
-$SHOT ./sharp-irm.step1.xodball main ./step1.patch.png 620
-$SHOT ./sharp-irm.step2.xodball gp2y0a02-range-meter ./step2a.patch.png 700
+"$SHOT" ./sharp-irm.step1.xodball main ./step1.patch.png 620
+"$SHOT" ./sharp-irm.step2.xodball gp2y0a02-range-meter ./step2a.patch.png 700
 # ./step2b.gif — can't autogenerate
-$SHOT ./sharp-irm.step3.xodball gp2y0a02-range-meter ./step3a.patch.png 780
-$SHOT ./sharp-irm.step3.xodball main ./step3b.patch.png 240
+"$SHOT" ./sharp-irm.step3.xodball gp2y0a02-range-meter ./step3a.patch.png 780
+"$SHOT" ./sharp-irm.step3.xodball main ./step3b.patch.png 240

--- a/docs/guide/buses/update-screenshots.sh
+++ b/docs/guide/buses/update-screenshots.sh
@@ -1,6 +1,6 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 SRC=example.xodball
 
-$SHOT $SRC no-buses ./no-buses.patch.png 500
-$SHOT $SRC with-buses ./with-buses.patch.png 700
+"$SHOT" "$SRC" no-buses ./no-buses.patch.png 500
+"$SHOT" "$SRC" with-buses ./with-buses.patch.png 700

--- a/docs/guide/cpp-state/update-screenshots.sh
+++ b/docs/guide/cpp-state/update-screenshots.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
-$SHOT ./cpp-state.xodball count ./outline.patch.png 350
+"$SHOT" ./cpp-state.xodball count ./outline.patch.png 350
 # ./test.gif — can't autogenerate

--- a/docs/guide/cpp-time/update-screenshots.sh
+++ b/docs/guide/cpp-time/update-screenshots.sh
@@ -1,5 +1,5 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
-$SHOT ./cpp-time.xodball tick ./outline.patch.png 350
+"$SHOT" ./cpp-time.xodball tick ./outline.patch.png 350
 #TODO: move button node a bit
-$SHOT ./cpp-time.xodball main ./test.patch.png 430
+"$SHOT" ./cpp-time.xodball main ./test.patch.png 430

--- a/docs/guide/creating-generics/update-screenshots.sh
+++ b/docs/guide/creating-generics/update-screenshots.sh
@@ -1,5 +1,5 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
-$SHOT ./samples.xodball abstract ./abstract.patch.png 360
-$SHOT ./samples.xodball composition ./composition.patch.png 540
-$SHOT ./samples.xodball terminals ./terminals.patch.png 360
+"$SHOT" ./samples.xodball abstract ./abstract.patch.png 360
+"$SHOT" ./samples.xodball composition ./composition.patch.png 540
+"$SHOT" ./samples.xodball terminals ./terminals.patch.png 360

--- a/docs/guide/creating-variadics/update-screenshots.sh
+++ b/docs/guide/creating-variadics/update-screenshots.sh
@@ -1,5 +1,5 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
-$SHOT ./samples.xodball pin-assignments ./assignments.patch.png 400
+"$SHOT" ./samples.xodball pin-assignments ./assignments.patch.png 400
 # ./join.patch.png
 # ./marker-error.patch.png

--- a/docs/guide/custom-types/update-screenshots.sh
+++ b/docs/guide/custom-types/update-screenshots.sh
@@ -1,8 +1,8 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
-$SHOT ./time.xodball format-iso-example ./format-iso-example.patch.png 450
-$SHOT ./time.xodball format-iso ./format-iso.patch.png 500
-$SHOT ./time.xodball pack ./pack.patch.png 700
-$SHOT ./time.xodball time ./time.patch.png 300
-$SHOT ./time.xodball unpack-example ./unpack-example.patch.png 450
-$SHOT ./time.xodball unpack ./unpack.patch.png 300
+"$SHOT" ./time.xodball format-iso-example ./format-iso-example.patch.png 450
+"$SHOT" ./time.xodball format-iso ./format-iso.patch.png 500
+"$SHOT" ./time.xodball pack ./pack.patch.png 700
+"$SHOT" ./time.xodball time ./time.patch.png 300
+"$SHOT" ./time.xodball unpack-example ./unpack-example.patch.png 450
+"$SHOT" ./time.xodball unpack ./unpack.patch.png 300

--- a/docs/guide/generics/update-screenshots.sh
+++ b/docs/guide/generics/update-screenshots.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
-$SHOT ./samples.xodball passes ./deduction.patch.png 600
-$SHOT ./samples.xodball if-else-samples ./if-else.patch.png 300
+"$SHOT" ./samples.xodball passes ./deduction.patch.png 600
+"$SHOT" ./samples.xodball if-else-samples ./if-else.patch.png 300

--- a/docs/guide/http-get/update-screenshots.sh
+++ b/docs/guide/http-get/update-screenshots.sh
@@ -1,6 +1,6 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 SRC=get-ip.xodball
 
-$SHOT $SRC 10-request ./request.patch.png 350
-$SHOT $SRC 20-print-ip ./print-ip.patch.png 750
+"$SHOT" "$SRC" 10-request ./request.patch.png 350
+"$SHOT" "$SRC" 20-print-ip ./print-ip.patch.png 750

--- a/docs/guide/nodes-for-xod-in-cpp/update-screenshots.sh
+++ b/docs/guide/nodes-for-xod-in-cpp/update-screenshots.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
-$SHOT ./cos-example.step1.xodball cos ./step1.patch.png 320
-$SHOT ./cos-example.step2.xodball cos ./step2.patch.png 320
+"$SHOT" ./cos-example.step1.xodball cos ./step1.patch.png 320
+"$SHOT" ./cos-example.step2.xodball cos ./step2.patch.png 320

--- a/docs/guide/nodes-for-xod-in-xod/update-screenshots.sh
+++ b/docs/guide/nodes-for-xod-in-xod/update-screenshots.sh
@@ -1,14 +1,14 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
-$SHOT ./my-utils.step1.xodball main ./step1.patch.png 640
+"$SHOT" ./my-utils.step1.xodball main ./step1.patch.png 640
 
-$SHOT ./my-utils.step2.xodball between ./step2.patch.png 640
+"$SHOT" ./my-utils.step2.xodball between ./step2.patch.png 640
 
-$SHOT ./my-utils.step3.xodball between ./step3a.patch.png 640
-$SHOT ./my-utils.step3.xodball main ./step3b.patch.png 320
+"$SHOT" ./my-utils.step3.xodball between ./step3a.patch.png 640
+"$SHOT" ./my-utils.step3.xodball main ./step3b.patch.png 320
 
-$SHOT ./my-utils.step4.xodball between ./step4a.patch.png 640
-$SHOT ./my-utils.step4.xodball main ./step4b.patch.png 320
+"$SHOT" ./my-utils.step4.xodball between ./step4a.patch.png 640
+"$SHOT" ./my-utils.step4.xodball main ./step4b.patch.png 320
 
-$SHOT ./my-utils.step5.xodball between ./step5a.patch.png 640
-$SHOT ./my-utils.step5.xodball main ./step5b.patch.png 320
+"$SHOT" ./my-utils.step5.xodball between ./step5a.patch.png 640
+"$SHOT" ./my-utils.step5.xodball main ./step5b.patch.png 320

--- a/docs/guide/sd-log-example/update-screenshots.sh
+++ b/docs/guide/sd-log-example/update-screenshots.sh
@@ -1,7 +1,7 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
-$SHOT ./sdcard-temp-screenshot.xodball sdcard-temp-1-screenshot ./sdcard-temp.step1.patch.png 600
-$SHOT ./sdcard-temp-screenshot.xodball sdcard-temp-2-screenshot ./sdcard-temp.step2.patch.png 600
-$SHOT ./sdcard-temp-screenshot.xodball sdcard-temp-3-screenshot ./sdcard-temp.step3.patch.png 600
-$SHOT ./sdcard-temp-screenshot.xodball sdcard-temp-screenshot ./sdcard-temp.patch.png 600
+"$SHOT" ./sdcard-temp-screenshot.xodball sdcard-temp-1-screenshot ./sdcard-temp.step1.patch.png 600
+"$SHOT" ./sdcard-temp-screenshot.xodball sdcard-temp-2-screenshot ./sdcard-temp.step2.patch.png 600
+"$SHOT" ./sdcard-temp-screenshot.xodball sdcard-temp-3-screenshot ./sdcard-temp.step3.patch.png 600
+"$SHOT" ./sdcard-temp-screenshot.xodball sdcard-temp-screenshot ./sdcard-temp.patch.png 600
 

--- a/docs/guide/simple-traffic-light/update-screenshots.sh
+++ b/docs/guide/simple-traffic-light/update-screenshots.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 # TODO: add more steps to xodball
-$SHOT ./traffic-light-simple.xodball state-green ./state-2.patch.png 540
+"$SHOT" ./traffic-light-simple.xodball state-green ./state-2.patch.png 540

--- a/docs/guide/variadics/update-screenshots.sh
+++ b/docs/guide/variadics/update-screenshots.sh
@@ -1,7 +1,7 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
-$SHOT ./samples.xodball 01-overview ./overview.patch.png 540
-$SHOT ./samples.xodball 02-expansion ./expansion.patch.png 640
-$SHOT ./samples.xodball 03-select-a2 ./select-a2.patch.png 540
-$SHOT ./samples.xodball 04-expansion-a2 ./select-a2-expansion.patch.png 540
-$SHOT ./samples.xodball 05-join-expansion ./join-expansion.patch.png 640
+"$SHOT" ./samples.xodball 01-overview ./overview.patch.png 540
+"$SHOT" ./samples.xodball 02-expansion ./expansion.patch.png 640
+"$SHOT" ./samples.xodball 03-select-a2 ./select-a2.patch.png 540
+"$SHOT" ./samples.xodball 04-expansion-a2 ./select-a2-expansion.patch.png 540
+"$SHOT" ./samples.xodball 05-join-expansion ./join-expansion.patch.png 640

--- a/docs/guide/w5500-advanced/update-screenshots.sh
+++ b/docs/guide/w5500-advanced/update-screenshots.sh
@@ -1,12 +1,12 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 SRC=w5500-connect.xodball
 
-$SHOT $SRC 10-device ./device.patch.png 300
-$SHOT $SRC 20-mac ./mac.patch.png 300
-$SHOT $SRC 30-connect-dhcp ./connect-dhcp.patch.png 350
-$SHOT $SRC 40-connect-out ./connect-out.patch.png 650
-$SHOT $SRC 50-connect-static ./connect-static.patch.png 650
-$SHOT $SRC 60-connect-static-ip ./connect-static-ip.patch.png 950
-$SHOT $SRC internet ./internet.patch.png 750
-$SHOT $SRC main ./main.patch.png 300
+"$SHOT" "$SRC" 10-device ./device.patch.png 300
+"$SHOT" "$SRC" 20-mac ./mac.patch.png 300
+"$SHOT" "$SRC" 30-connect-dhcp ./connect-dhcp.patch.png 350
+"$SHOT" "$SRC" 40-connect-out ./connect-out.patch.png 650
+"$SHOT" "$SRC" 50-connect-static ./connect-static.patch.png 650
+"$SHOT" "$SRC" 60-connect-static-ip ./connect-static-ip.patch.png 950
+"$SHOT" "$SRC" internet ./internet.patch.png 750
+"$SHOT" "$SRC" main ./main.patch.png 300

--- a/docs/guide/w5500-connect/update-screenshots.sh
+++ b/docs/guide/w5500-connect/update-screenshots.sh
@@ -1,6 +1,6 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 SRC=w5500-connect.xodball
 
-$SHOT $SRC 10-ethernet-shield ./ethernet-shield.patch.png 300
-$SHOT $SRC 20-lan-ip-output ./lan-ip-output.patch.png 450
+"$SHOT" "$SRC" 10-ethernet-shield ./ethernet-shield.patch.png 300
+"$SHOT" "$SRC" 20-lan-ip-output ./lan-ip-output.patch.png 450

--- a/docs/reference/data-types/update-screenshots.sh
+++ b/docs/reference/data-types/update-screenshots.sh
@@ -1,5 +1,5 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 SRC=types.xodball
 
-$SHOT $SRC color-code ./color-code.patch.png 450
+"$SHOT" "$SRC" color-code ./color-code.patch.png 450

--- a/docs/tutorial/02-deploy/update-screenshots.sh
+++ b/docs/tutorial/02-deploy/update-screenshots.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
-$SHOT ../tutorial-update-screenshot.xodball 02-deploy ./patch.png 400
+"$SHOT" ../tutorial-update-screenshot.xodball 02-deploy ./patch.png 400
 

--- a/docs/tutorial/07-labels/update-screenshots.sh
+++ b/docs/tutorial/07-labels/update-screenshots.sh
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
-$SHOT ../tutorial-update-screenshot.xodball 07-labels ./patch.png 500
+"$SHOT" ../tutorial-update-screenshot.xodball 07-labels ./patch.png 500

--- a/docs/tutorial/08-constants/update-screenshots.sh
+++ b/docs/tutorial/08-constants/update-screenshots.sh
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
-$SHOT ../tutorial-update-screenshot.xodball 08-constants ./patch.png 400
+"$SHOT" ../tutorial-update-screenshot.xodball 08-constants ./patch.png 400

--- a/docs/tutorial/09-pot/update-screenshots.sh
+++ b/docs/tutorial/09-pot/update-screenshots.sh
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
-$SHOT ../tutorial-update-screenshot.xodball 09-pot ./patch.png 400
+"$SHOT" ../tutorial-update-screenshot.xodball 09-pot ./patch.png 400

--- a/docs/tutorial/10-math/update-screenshots.sh
+++ b/docs/tutorial/10-math/update-screenshots.sh
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
-$SHOT ../tutorial-update-screenshot.xodball 10-math ./patch.png 500
+"$SHOT" ../tutorial-update-screenshot.xodball 10-math ./patch.png 500

--- a/docs/tutorial/11-servo/update-screenshots.sh
+++ b/docs/tutorial/11-servo/update-screenshots.sh
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
-$SHOT ../tutorial-update-screenshot.xodball 11-servo ./patch.png 400
+"$SHOT" ../tutorial-update-screenshot.xodball 11-servo ./patch.png 400

--- a/docs/tutorial/13-map/update-screenshots.sh
+++ b/docs/tutorial/13-map/update-screenshots.sh
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
-$SHOT ../tutorial-update-screenshot.xodball 13-map ./patch.png 400
+"$SHOT" ../tutorial-update-screenshot.xodball 13-map ./patch.png 400

--- a/docs/tutorial/14-map-adjust/update-screenshots.sh
+++ b/docs/tutorial/14-map-adjust/update-screenshots.sh
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
-$SHOT ../tutorial-update-screenshot.xodball 14-map-adjust ./patch.png 400
+"$SHOT" ../tutorial-update-screenshot.xodball 14-map-adjust ./patch.png 400

--- a/docs/tutorial/15-buttons/update-screenshots.sh
+++ b/docs/tutorial/15-buttons/update-screenshots.sh
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
-$SHOT ../tutorial-update-screenshot.xodball 15-buttons ./patch.png 400
+"$SHOT" ../tutorial-update-screenshot.xodball 15-buttons ./patch.png 400

--- a/docs/tutorial/16-logic/update-screenshots.sh
+++ b/docs/tutorial/16-logic/update-screenshots.sh
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
-$SHOT ../tutorial-update-screenshot.xodball 16-logic ./patch.png 500
+"$SHOT" ../tutorial-update-screenshot.xodball 16-logic ./patch.png 500

--- a/docs/tutorial/17-ldr/update-screenshots.sh
+++ b/docs/tutorial/17-ldr/update-screenshots.sh
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
-$SHOT ../tutorial-update-screenshot.xodball 17-ldr ./patch.png 400
+"$SHOT" ../tutorial-update-screenshot.xodball 17-ldr ./patch.png 400

--- a/docs/tutorial/18-comparisons/update-screenshots.sh
+++ b/docs/tutorial/18-comparisons/update-screenshots.sh
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
-$SHOT ../tutorial-update-screenshot.xodball 18-comparisons ./patch.png 400
+"$SHOT" ../tutorial-update-screenshot.xodball 18-comparisons ./patch.png 400

--- a/docs/tutorial/19-if-else/update-screenshots.sh
+++ b/docs/tutorial/19-if-else/update-screenshots.sh
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
-$SHOT ../tutorial-update-screenshot.xodball 19-if-else ./patch.png 500
+"$SHOT" ../tutorial-update-screenshot.xodball 19-if-else ./patch.png 500

--- a/docs/tutorial/20-fade/update-screenshots.sh
+++ b/docs/tutorial/20-fade/update-screenshots.sh
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
-$SHOT ../tutorial-update-screenshot.xodball 20-fade ./patch.png 600
+"$SHOT" ../tutorial-update-screenshot.xodball 20-fade ./patch.png 600

--- a/docs/tutorial/21-pulses/update-screenshots.sh
+++ b/docs/tutorial/21-pulses/update-screenshots.sh
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
-$SHOT ../tutorial-update-screenshot.xodball 21-pulses ./patch.png 350
+"$SHOT" ../tutorial-update-screenshot.xodball 21-pulses ./patch.png 350

--- a/docs/tutorial/22-clock/update-screenshots.sh
+++ b/docs/tutorial/22-clock/update-screenshots.sh
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
-$SHOT ../tutorial-update-screenshot.xodball 22-clock ./patch.png 400
+"$SHOT" ../tutorial-update-screenshot.xodball 22-clock ./patch.png 400

--- a/docs/tutorial/23-count/update-screenshots.sh
+++ b/docs/tutorial/23-count/update-screenshots.sh
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
-$SHOT ../tutorial-update-screenshot.xodball 23-count ./patch.png 400
+"$SHOT" ../tutorial-update-screenshot.xodball 23-count ./patch.png 400

--- a/docs/tutorial/24-flip-flop/update-screenshots.sh
+++ b/docs/tutorial/24-flip-flop/update-screenshots.sh
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
-$SHOT ../tutorial-update-screenshot.xodball 24-flip-flop ./patch.png 400
+"$SHOT" ../tutorial-update-screenshot.xodball 24-flip-flop ./patch.png 400

--- a/docs/tutorial/25-multiple-timelines/update-screenshots.sh
+++ b/docs/tutorial/25-multiple-timelines/update-screenshots.sh
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
-$SHOT ../tutorial-update-screenshot.xodball 25-multiple-timelines ./patch.png 850
+"$SHOT" ../tutorial-update-screenshot.xodball 25-multiple-timelines ./patch.png 850

--- a/docs/tutorial/26-lcd/update-screenshots.sh
+++ b/docs/tutorial/26-lcd/update-screenshots.sh
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
-$SHOT ../tutorial-update-screenshot.xodball 26-lcd ./patch.png 350
+"$SHOT" ../tutorial-update-screenshot.xodball 26-lcd ./patch.png 350

--- a/docs/tutorial/27-lcd-data/update-screenshots.sh
+++ b/docs/tutorial/27-lcd-data/update-screenshots.sh
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
-$SHOT ../tutorial-update-screenshot.xodball 27-lcd-data ./patch.png 350
+"$SHOT" ../tutorial-update-screenshot.xodball 27-lcd-data ./patch.png 350

--- a/docs/tutorial/28-string-concat/update-screenshots.sh
+++ b/docs/tutorial/28-string-concat/update-screenshots.sh
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
-$SHOT ../tutorial-update-screenshot.xodball 28-string-concat ./patch.png 400
+"$SHOT" ../tutorial-update-screenshot.xodball 28-string-concat ./patch.png 400


### PR DESCRIPTION
Allow spaces in path to `xod` or to `xod-docs`.

Also, use classic shell shebang.